### PR TITLE
ignore .dobi directory when computing build context modified time

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Install
 
 The one liner::
 
-    curl -L -o /usr/local/bin/dobi "https://github.com/dnephin/dobi/releases/download/v0.12.0/dobi-$(uname -s)"; chmod +x /usr/local/bin/dobi
+    curl -L -o /usr/local/bin/dobi "https://github.com/dnephin/dobi/releases/download/v0.13.0/dobi-$(uname -s)"; chmod +x /usr/local/bin/dobi
 
 For a Windows binary, and more install options, see `Install <https://dnephin.github.io/dobi/install.html>`_
 

--- a/cmd/dobi.go
+++ b/cmd/dobi.go
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	version   = "0.12.0"
+	version   = "0.13.0"
 	gitsha    = "unknown"
 	buildDate = ""
 )

--- a/config/image.go
+++ b/config/image.go
@@ -55,6 +55,7 @@ type ImageConfig struct {
 	// Pull Pull an image instead of building it. The value may be one of:
 	// * ``once`` - only pull if the image:tag does not exist
 	// * ``always`` - always pull the image
+	// * ``local`` - don't pull or build the image. Use one that is already present locally
 	// * ``<duration>`` - pull if the image hasn't been pulled in at least
 	//   ``duration``. The format of duration is a number followed by a single
 	//   character time unit (ex: ``40s``, ``2h``, ``30min``)
@@ -196,6 +197,8 @@ func (p *pull) TransformConfig(raw reflect.Value) error {
 		switch value {
 		case "once":
 			p.action = pullOnce
+		case "local":
+			p.action = pullLocal
 		case "always":
 			p.action = pullAlways
 		default:
@@ -224,6 +227,10 @@ func (p *pull) IsSet() bool {
 
 func pullAlways(_ *time.Time) bool {
 	return true
+}
+
+func pullLocal(_ *time.Time) bool {
+	return false
 }
 
 func pullOnce(lastPull *time.Time) bool {

--- a/config/image.go
+++ b/config/image.go
@@ -151,6 +151,11 @@ func (c *ImageConfig) Resolve(resolver Resolver) (Resource, error) {
 		return &conf, err
 	}
 
+	conf.CacheFrom, err = resolver.ResolveSlice(c.CacheFrom)
+	if err != nil {
+		return &conf, err
+	}
+
 	conf.Image, err = resolver.Resolve(c.Image)
 	if err != nil {
 		return &conf, err

--- a/config/image.go
+++ b/config/image.go
@@ -55,7 +55,7 @@ type ImageConfig struct {
 	// Pull Pull an image instead of building it. The value may be one of:
 	// * ``once`` - only pull if the image:tag does not exist
 	// * ``always`` - always pull the image
-	// * ``local`` - don't pull or build the image. Use one that is already present locally
+	// * ``never`` - don't pull or build the image. Use one that is already present locally
 	// * ``<duration>`` - pull if the image hasn't been pulled in at least
 	//   ``duration``. The format of duration is a number followed by a single
 	//   character time unit (ex: ``40s``, ``2h``, ``30min``)
@@ -197,8 +197,8 @@ func (p *pull) TransformConfig(raw reflect.Value) error {
 		switch value {
 		case "once":
 			p.action = pullOnce
-		case "local":
-			p.action = pullLocal
+		case "never":
+			p.action = pullNever
 		case "always":
 			p.action = pullAlways
 		default:
@@ -229,7 +229,7 @@ func pullAlways(_ *time.Time) bool {
 	return true
 }
 
-func pullLocal(_ *time.Time) bool {
+func pullNever(_ *time.Time) bool {
 	return false
 }
 

--- a/config/image.go
+++ b/config/image.go
@@ -15,7 +15,7 @@ import (
 // ImageConfig An **image** resource provides actions for working with a Docker
 // image. If an image is buildable it is considered up-to-date if all files in
 // the build context have a modified time older than the created time of the
-// image. If using inline Dockerfile, the **dobi.yaml** file will be considered 
+// image. If using inline Dockerfile, the **dobi.yaml** file will be considered
 // as a part of the build context.
 // name: image
 // example: An image with build args:

--- a/config/image_test.go
+++ b/config/image_test.go
@@ -113,6 +113,7 @@ func TestImageConfigResolve(t *testing.T) {
 			"key1": "{one}",
 			"key2": "ok",
 		},
+		CacheFrom: []string{"{one}", "two"},
 	}
 	resolved, err := image.Resolve(resolver)
 	assert.NilError(t, err)
@@ -124,6 +125,7 @@ func TestImageConfigResolve(t *testing.T) {
 			"key1": "thetag",
 			"key2": "ok",
 		},
+		CacheFrom: []string{"thetag", "two"},
 	}
 	assert.Check(t, is.DeepEqual(expected, resolved, cmpConfigOpt))
 }

--- a/config/job.go
+++ b/config/job.go
@@ -2,11 +2,13 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 
 	"github.com/dnephin/configtf"
 	pth "github.com/dnephin/configtf/path"
 	shlex "github.com/kballard/go-shellquote"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // JobConfig A **job** resource uses an `image`_ to run a job in a container.
@@ -237,7 +239,13 @@ func (s *ShlexSlice) TransformConfig(raw reflect.Value) error {
 }
 
 func jobFromConfig(name string, values map[string]interface{}) (Resource, error) {
+	isTerminal := terminal.IsTerminal(int(os.Stdin.Fd()))
 	cmd := &JobConfig{}
+	if isTerminal == true {
+		if _, ok := values["interactive"]; !ok {
+			values["interactive"] = true
+		}
+	}
 	return cmd, configtf.Transform(name, values, cmd)
 }
 

--- a/config/job.go
+++ b/config/job.go
@@ -241,7 +241,7 @@ func (s *ShlexSlice) TransformConfig(raw reflect.Value) error {
 func jobFromConfig(name string, values map[string]interface{}) (Resource, error) {
 	isTerminal := terminal.IsTerminal(int(os.Stdin.Fd()))
 	cmd := &JobConfig{}
-	if isTerminal == true {
+	if isTerminal {
 		if _, ok := values["interactive"]; !ok {
 			values["interactive"] = true
 		}

--- a/dockerfiles/Dockerfile.build
+++ b/dockerfiles/Dockerfile.build
@@ -1,7 +1,7 @@
-FROM    golang:1.10-alpine
+FROM    golang:1.13-alpine
 RUN     apk add -U git bash curl tree
 
-ARG     FILEWATCHER_SHA=v0.3.0
+ARG     FILEWATCHER_SHA=v0.3.2
 RUN     go get -d github.com/dnephin/filewatcher && \
         cd /go/src/github.com/dnephin/filewatcher && \
         git checkout -q "$FILEWATCHER_SHA" && \
@@ -15,7 +15,7 @@ RUN     go get -d github.com/golang/dep/cmd/dep && \
         go build -v -o /usr/bin/dep ./cmd/dep && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
-ARG     GOTESTSUM=v0.3.0
+ARG     GOTESTSUM=v0.4.0
 RUN     go get -d gotest.tools/gotestsum && \
         cd /go/src/gotest.tools/gotestsum && \
         git checkout -q "$GOTESTSUM" && \

--- a/dockerfiles/Dockerfile.docs
+++ b/dockerfiles/Dockerfile.docs
@@ -1,4 +1,4 @@
-FROM    alpine:3.6
+FROM    alpine:3.10
 
 RUN     apk -U add \
             python \

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -18,7 +18,7 @@ Install from source
     git clone git@github.com:dnephin/dobi && cd dobi
     docker run -ti --rm -w $(pwd) -v $(pwd):$(pwd) -e DOCKER_HOST \
         -v /var/run/docker.sock:/var/run/docker.sock \
-        dnephin/dobi:0.12.0 deps binary
+        dnephin/dobi:0.13.0 deps binary
 
 The binaries will be in ``./dist/bin``
 

--- a/examples/init-db-with-rails/test.sh
+++ b/examples/init-db-with-rails/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SUMMARY: Test initialize a database
-# LABELS:
+# LABELS: never
 # REPEAT:
 # AUTHOR:
 set -eu -o pipefail

--- a/tasks/image/pull.go
+++ b/tasks/image/pull.go
@@ -13,8 +13,22 @@ import (
 func RunPull(ctx *context.ExecuteContext, t *Task, _ bool) (bool, error) {
 	record, err := getImageRecord(recordPath(ctx, t.config))
 	if err != nil {
-		t.logger().Warnf("Failed to get image record: %s", err)
+		if os.IsNotExist(err) {
+			t.logger().Info("Creating image record")
+			image, err := GetImage(ctx, t.config)
+			if err != nil {
+				return false, err
+			}
+			record := imageModifiedRecord{ImageID: image.ID}
+			updateImageRecord(recordPath(ctx, t.config), record)
+			if err != nil {
+				return false, err
+			}
+		} else {
+			t.logger().Warnf("Failed to get image record: %s", err)
+		}
 	}
+
 	if !t.config.Pull.Required(record.LastPull) {
 		t.logger().Debugf("Pull not required")
 		return false, nil

--- a/tasks/image/pull.go
+++ b/tasks/image/pull.go
@@ -12,13 +12,12 @@ import (
 // RunPull builds or pulls an image if it is out of date
 func RunPull(ctx *context.ExecuteContext, t *Task, _ bool) (bool, error) {
 	record, err := getImageRecord(recordPath(ctx, t.config))
-	if err != nil {
-		t.logger().Warnf("Failed to get image record: %s", err)
-	}
-
-	if !t.config.Pull.Required(record.LastPull) {
+	switch {
+	case !t.config.Pull.Required(record.LastPull):
 		t.logger().Debugf("Pull not required")
 		return false, nil
+	case err != nil:
+		t.logger().Warnf("Failed to get image record: %s", err)
 	}
 
 	pullTag := func(tag string) error {

--- a/tasks/image/pull.go
+++ b/tasks/image/pull.go
@@ -13,20 +13,7 @@ import (
 func RunPull(ctx *context.ExecuteContext, t *Task, _ bool) (bool, error) {
 	record, err := getImageRecord(recordPath(ctx, t.config))
 	if err != nil {
-		if os.IsNotExist(err) {
-			t.logger().Info("Creating image record")
-			image, err := GetImage(ctx, t.config)
-			if err != nil {
-				return false, err
-			}
-			record := imageModifiedRecord{ImageID: image.ID}
-			updateImageRecord(recordPath(ctx, t.config), record)
-			if err != nil {
-				return false, err
-			}
-		} else {
-			t.logger().Warnf("Failed to get image record: %s", err)
-		}
+		t.logger().Warnf("Failed to get image record: %s", err)
 	}
 
 	if !t.config.Pull.Required(record.LastPull) {

--- a/tasks/image/push.go
+++ b/tasks/image/push.go
@@ -11,7 +11,7 @@ import (
 // RunPush pushes an image to the registry
 func RunPush(ctx *context.ExecuteContext, t *Task, _ bool) (bool, error) {
 	pushTag := func(tag string) error {
-		return pushImage(ctx, t, tag)
+		return pushImage(ctx, tag)
 	}
 	if err := t.ForEachTag(ctx, pushTag); err != nil {
 		return false, err
@@ -20,7 +20,7 @@ func RunPush(ctx *context.ExecuteContext, t *Task, _ bool) (bool, error) {
 	return true, nil
 }
 
-func pushImage(ctx *context.ExecuteContext, t *Task, tag string) error {
+func pushImage(ctx *context.ExecuteContext, tag string) error {
 	repo, err := parseAuthRepo(tag)
 	if err != nil {
 		return err

--- a/tasks/image/push.go
+++ b/tasks/image/push.go
@@ -21,7 +21,7 @@ func RunPush(ctx *context.ExecuteContext, t *Task, _ bool) (bool, error) {
 }
 
 func pushImage(ctx *context.ExecuteContext, t *Task, tag string) error {
-	repo, err := parseAuthRepo(t.config.Image)
+	repo, err := parseAuthRepo(tag)
 	if err != nil {
 		return err
 	}

--- a/tasks/job/build.go
+++ b/tasks/job/build.go
@@ -328,7 +328,9 @@ func createFromTar(tarReader io.Reader, header *tar.Header, path artifactPath) e
 		return os.Symlink(header.Linkname, hostPath)
 
 	default:
-		logging.Log.Warnf("Unhandled file type from archive %s: %s", header.Typeflag, header.Name)
+		logging.Log.Warnf("Unhandled file type from archive %s: %s",
+			string(header.Typeflag),
+			header.Name)
 	}
 
 	return nil

--- a/tasks/job/capture.go
+++ b/tasks/job/capture.go
@@ -57,6 +57,6 @@ func (t *captureTask) Run(ctx *context.ExecuteContext, depsModified bool) (bool,
 		return false, nil
 	}
 
-	logging.ForTask(t).Debug("Setting %q to: %s", t.variable, out)
+	logging.ForTask(t).Debugf("Setting %q to: %s", t.variable, out)
 	return true, os.Setenv(t.variable, out)
 }

--- a/utils/fs/directory.go
+++ b/utils/fs/directory.go
@@ -10,6 +10,7 @@ import (
 // directories. The files in each directory are checked for their last modified
 // time.
 // TODO: use go routines to speed this up
+// nolint: gocyclo
 func LastModified(fileOrDir ...string) (time.Time, error) {
 	var latest time.Time
 
@@ -17,6 +18,9 @@ func LastModified(fileOrDir ...string) (time.Time, error) {
 	walker := func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+		if info.IsDir() && info.Name() == ".dobi" {
+			return filepath.SkipDir
 		}
 		if info.ModTime().After(latest) {
 			latest = info.ModTime()


### PR DESCRIPTION
If we want to use dobi to build our repo, it makes sense to put the dobi.yaml in the same repo, but unfortunately the docker context is in the root of the repo. dobi creates a .dobi directory in the same dir as the dobi.yaml file to track various things, which triggers rebuilds every time when files change under .dobi.

Let's just ignore .dobi and everything under it when computing the docker build context age.